### PR TITLE
Fix for no dimensions for an alarm

### DIFF
--- a/cloud/amazon/ec2_metric_alarm.py
+++ b/cloud/amazon/ec2_metric_alarm.py
@@ -186,6 +186,9 @@ def create_metric_alarm(connection, module):
 
         dim1 = module.params.get('dimensions')
         dim2 = alarm.dimensions
+        
+        if not dim1:
+         dim1 = {}
 
         for keys in dim1:
             if not isinstance(dim1[keys], list):


### PR DESCRIPTION
If you leave out the dimensions:, the script will function correctly.

Adding {} to the module.params.get does result in a NoneType.
